### PR TITLE
fix: 카카오 맵 위도,경도 number->string으로 변경

### DIFF
--- a/src/components/place/index.tsx
+++ b/src/components/place/index.tsx
@@ -156,8 +156,8 @@ const Place = ({ lng, lat, local }: PlaceProps) => {
               setModalClick={setModalClick}
               detail={data?.detail as BestRegionPlaceDetailProps}
               category={category}
-              lng={parseInt(lng)}
-              lat={parseInt(lat)}
+              lng={lng}
+              lat={lat}
               thumUrls={data?.detail.thumUrls as string[]}
               menu={data?.detail.menuInfo as string[]}
             />

--- a/src/components/placeDetail/PlaceDetailLocation.tsx
+++ b/src/components/placeDetail/PlaceDetailLocation.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
 
 interface KakaoMapProps {
-  lng: number;
-  lat: number;
+  lng: string;
+  lat: string;
 }
 
 const PlaceDetailLocation = ({ lng, lat }: KakaoMapProps) => {

--- a/src/components/placeDetail/index.tsx
+++ b/src/components/placeDetail/index.tsx
@@ -18,8 +18,8 @@ interface PlaceDetailProps {
   setModalClick: React.Dispatch<React.SetStateAction<boolean>>;
   detail: BestRegionPlaceDetailProps;
   category: keyof typeof ChipList;
-  lng: number;
-  lat: number;
+  lng: string;
+  lat: string;
   thumUrls: string[];
   menu: string[];
 }

--- a/src/components/placeDetail/index.tsx
+++ b/src/components/placeDetail/index.tsx
@@ -7,6 +7,7 @@ import PlaceDetailLocation from './PlaceDetailLocation';
 import PlaceDetailPhoto from './PlaceDetailPhoto';
 import PlaceDetailPrice from './PlaceDetailPrice';
 import MapMore from '../common/button/map';
+import { useRouter } from 'next/router';
 
 export type PLACE_NAV_LIST = 'LOCATION' | 'PRICE' | 'PHOTO';
 interface PlaceDetailProps {
@@ -38,10 +39,14 @@ const PlaceDetail = ({
   menu,
 }: PlaceDetailProps) => {
   const [placeNav, setPlaceNav] = useState<PLACE_NAV_LIST>('LOCATION');
+  const router = useRouter();
+  const handleMapMoreClick = () => {
+    router.push(`https://m.map.naver.com/search2/search.naver?query=${title}#/map/1`);
+  };
 
   return (
     <div
-      className="fixed flex justify-center items-center flex-row top-0 right-0 left-0 w-[100vw] h-[100vh] z-10 "
+      className="fixed flex justify-center items-center flex-row top-0 right-0 left-0 w-[100vw] h-[100vh] z-10  "
       style={{ backgroundColor: 'rgba( 0, 0, 0, 0.6 )' }}>
       <div className="display block p-[32px]">
         <div className="rounded-xl w-[1200px] max-h-[90vh] bg-white z-20 pt-[400px] pb-[100px] overflow-scroll flex justify-center items-center flex-col ">
@@ -55,12 +60,15 @@ const PlaceDetail = ({
             detail={detail}
             category={category}
           />
+          <div>{``}</div>
           <PlaceNavBar placeNav={placeNav} setPlaceNav={setPlaceNav} />
           {placeNav == 'LOCATION' && (
             <div className="flex justify-center items-center flex-col">
               <PlaceDetailLocation lng={lng} lat={lat} />
               <div className="p-[40px]"></div>
-              <MapMore />
+              <div onClick={handleMapMoreClick}>
+                <MapMore />
+              </div>
             </div>
           )}
           {placeNav == 'PHOTO' && (


### PR DESCRIPTION
# ISSUE Number✅ : #57 

## 📖 Summary

- 장소추천에서 모달 클릭했을때 
<img width="880" alt="image" src="https://github.com/moidot/frontend/assets/85864699/8910db2b-43ce-427c-bad9-6a8a5502ff5f">
lat,lng을 정수로 받아버려서 위도,경도가 이상하게 나오는 문제 해결
- 네이버 지도에서 보러가기 버튼 클릭시 -> 네이버 지도로 라우팅되게 문제 해결
